### PR TITLE
swagger에서 헤더로 토큰 전달 가능하게 기능 추가

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -8,7 +8,12 @@ import {
   UseGuards,
 } from "@nestjs/common";
 import { AuthService } from "./auth.service";
-import { ApiOperation, ApiQuery, ApiResponse } from "@nestjs/swagger";
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiQuery,
+  ApiResponse,
+} from "@nestjs/swagger";
 import { RefreshTokenAuthGuard } from "./jwt.guard";
 import { userNo } from "./auth.decorator";
 import { Response } from "express";
@@ -75,11 +80,7 @@ export class AuthController {
   @UseGuards(RefreshTokenAuthGuard)
   @Get("new-access-token")
   @ApiOperation({ summary: "액세스 토큰 재발급" })
-  @ApiQuery({
-    name: "refreshTOken",
-    description: "리프레쉬 토큰",
-    required: true,
-  })
+  @ApiBearerAuth("refresh-token")
   @ApiResponse({
     status: 200,
     description: "액세스 토큰 재발급 성공",

--- a/src/auth/jwt.guard.ts
+++ b/src/auth/jwt.guard.ts
@@ -2,7 +2,6 @@ import {
   BadRequestException,
   ExecutionContext,
   HttpException,
-  HttpStatus,
   Injectable,
   NotFoundException,
   UnauthorizedException,
@@ -92,7 +91,7 @@ export class RefreshTokenAuthGuard extends AuthGuard("refreshToken") {
       if (error.message === "Token not found.") {
         throw new NotFoundException("Token not found.");
       } else {
-        console.log(error);
+        console.log(error.message);
         throw new BadRequestException("jwt error");
       }
     }

--- a/src/auth/jwt.guard.ts
+++ b/src/auth/jwt.guard.ts
@@ -91,7 +91,7 @@ export class RefreshTokenAuthGuard extends AuthGuard("refreshToken") {
       if (error.message === "Token not found.") {
         throw new NotFoundException("Token not found.");
       } else {
-        console.log(error.message);
+        console.log(error);
         throw new BadRequestException("jwt error");
       }
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,6 +14,26 @@ async function bootstrap() {
     .setTitle("Modern World API")
     .setDescription("API of Modern World")
     .setVersion("0.1")
+    .addBearerAuth(
+      {
+        type: "http",
+        scheme: "bearer",
+        name: "JWT",
+        description: "Enter JWT token",
+        in: "header",
+      },
+      "refresh-token",
+    )
+    .addBearerAuth(
+      {
+        type: "http",
+        scheme: "bearer",
+        name: "JWT",
+        description: "Enter JWT token",
+        in: "header",
+      },
+      "access-token",
+    )
     .build();
 
   const document = SwaggerModule.createDocument(app, config);


### PR DESCRIPTION
머지후 정상 동작 확인중에 swagger로 토큰 전달이 안되는 오류 발견해서 main.ts에 토큰을 헤더로 전달할 수 있게끔 main.ts에 추가했습니다. 추후 리팩토링 때 리프레시 토큰은 쿠키로 전달하게끔 수정할 예정입니다. 컨트롤러에서  @ApiBearerAuth("토큰 종류") 이런식으로 사용하시면 됩니다.