### PR TITLE
Feature/#44/achievement

### DIFF
--- a/src/comments/comments.module.ts
+++ b/src/comments/comments.module.ts
@@ -3,9 +3,11 @@ import { CommentService } from "./comments.service";
 import { CommentController } from "./comments.controller";
 import { CommentRepository } from "./comments.repository";
 import { UsersModule } from "src/users/users.module";
+import { CommonModule } from "src/common/common.module";
+import { LegendsModule } from "src/legends/legends.module";
 
 @Module({
-  imports: [UsersModule],
+  imports: [UsersModule, CommonModule, LegendsModule],
   controllers: [CommentController],
   providers: [CommentService, CommentRepository],
 })

--- a/src/common/common.module.ts
+++ b/src/common/common.module.ts
@@ -1,4 +1,4 @@
-import { Module } from "@nestjs/common";
+import { forwardRef, Module } from "@nestjs/common";
 import { CommonService } from "./common.service";
 import { UsersModule } from "src/users/users.module";
 import { LegendsModule } from "src/legends/legends.module";
@@ -9,7 +9,7 @@ import { AchievementsModule } from "src/achievements/achievements.module";
 
 @Module({
   imports: [
-    UsersModule,
+    forwardRef(() => UsersModule),
     LegendsModule,
     UserAchievementsModule,
     SseModule,

--- a/src/common/common.service.ts
+++ b/src/common/common.service.ts
@@ -27,7 +27,7 @@ export class CommonService {
 
   async checkAchievementCondition(
     userNo: number,
-    legendOneField: keyof UpdateLegendCount,
+    legendField: keyof UpdateLegendCount,
   ) {
     const userLegend =
       await this.legendsRepository.getAllLegendsByUserNo(userNo);
@@ -36,33 +36,33 @@ export class CommonService {
     // 총 15개의 업적. 5(업적 종류) * 3(업적단계) legend table의 feild 값이10, 20, 40일떄 이벤트 발생
     // achievement name은 ~Count1, ~Count2, ~Count3로 구성됨 사실 이러면 name의 역할은 DB 검색용 역할로 전락함
     // 그러나 title(칭호)가 있으니까 프론트는 이거쓰면 됨ㅇㅇ
-    switch (userLegend[`${legendOneField}`]) {
+    switch (userLegend[`${legendField}`]) {
       case 10:
-        this.checkAchievementConditonAndGet(userNo, legendOneField + 1);
+        this.checkAchievementAndGet(userNo, legendField + 1);
         break;
       case 20:
-        this.checkAchievementConditonAndGet(userNo, legendOneField + 2);
+        this.checkAchievementAndGet(userNo, legendField + 2);
         break;
       case 40:
-        this.checkAchievementConditonAndGet(userNo, legendOneField + 3);
+        this.checkAchievementAndGet(userNo, legendField + 3);
     }
   }
 
-  private async checkAchievementConditonAndGet(
+  private async checkAchievementAndGet(
     userNo: number,
-    legendOneFieldWithNumber: string,
+    legendFieldWithNumber: string,
   ) {
     if (
       //해당 하는 업적을 가지고 있는지 확인
       !(await this.usersAchievementsRepository.findOneAchievementByName(
         userNo,
-        legendOneFieldWithNumber,
+        legendFieldWithNumber,
       ))
     ) {
       //해당 업적 정보얻기
       const { no, point, title } =
         await this.achievementsRepository.getAchievementNoByName(
-          legendOneFieldWithNumber,
+          legendFieldWithNumber,
         );
 
       try {

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -1,11 +1,12 @@
-import { Module } from "@nestjs/common";
+import { forwardRef, Module } from "@nestjs/common";
 import { UsersController } from "./users.controller";
 import { UsersService } from "./users.service";
-import { UsersRepository as UsersRepository } from "./users.repository";
-import { SseModule } from "src/sse/sse.module";
+import { UsersRepository } from "./users.repository";
+import { CommonModule } from "src/common/common.module";
+import { LegendsModule } from "src/legends/legends.module";
 
 @Module({
-  imports: [SseModule],
+  imports: [forwardRef(() => CommonModule), LegendsModule],
   controllers: [UsersController],
   providers: [UsersService, UsersRepository],
   exports: [UsersRepository],


### PR DESCRIPTION
## 관련 이슈

#44 

## 개요

> - 유저가 출석을 했을 때 출석횟수가 업적 조건에 해당하는지 확인하는 로직 추가
> - 유저가 댓글(comment,  reply 포함)을 달았을 때 업적 조건에 해당하는지 확인하는 로직  추가
> - commonService 관련 메서드명 변경

## 작업 상세 내용

- [x] 유저가 출석을 했을 때 출석횟수가 업적 조건에 해당하는지 확인하는 로직 추가
- userAttendance (유저 출석관련) 로직은 일단 back쪽에서 한국시간 기준으로 맞춰주는 거로 하긴 했는데, 해당 부분은 좀더 얘기좀 해봐야겠습니다.
- 그리고 해당 로직을 구현하기 위해 어쩔수 없이 순환 종속성 문제가 발생해서 forwardRef 관련 함수 사용했습니다.

- [x] 유저가 댓글(comment,  reply 포함)을 달았을 때 업적 조건에 해당하는지 확인하는 로직  추가 (legend테이블의 commentCount에는 comment + reply를 한 갯수가 들어갑니다.)
- 관련 항목은 like와는 다르게 comment 또는 reply를 삭제할 때 legend table의 commentCount가 -가 되지 않습니다. 오직 누적 개수만 들어갑니다.

- [x] commonService 관련 메서드명 변경

## 하고싶은 말
해당 PR이 merge 되면 다음일은 #75 관련 작업 들어가도록 하겠습니다.
근데 보다보니 logger도 손볼 필요가 있어보이네요...