### PR TITLE
Feature/#96/post alarm

### DIFF
--- a/src/alarms/alarms.repository.ts
+++ b/src/alarms/alarms.repository.ts
@@ -2,6 +2,7 @@ import { Injectable } from "@nestjs/common";
 import { PrismaPromise, alarm } from "@prisma/client";
 import { OrderBy } from "src/common/enum/order-by.enum";
 import { PrismaService } from "src/prisma/prisma.service";
+import { PrismaTxType } from "src/prisma/prisma.type";
 
 @Injectable()
 export class AlarmsRepository {
@@ -29,8 +30,15 @@ export class AlarmsRepository {
     return this.prisma.alarm.findUnique({ where: { no: alarmNo } });
   }
 
-  createOneAlarm(userNo: number, content: string, title?: string) {
-    return this.prisma.alarm.create({ data: { userNo, content, title } });
+  createOneAlarm(
+    userNo: number,
+    content: string,
+    title?: string,
+    tx?: PrismaTxType,
+  ) {
+    return (tx ?? this.prisma).alarm.create({
+      data: { userNo, content, title },
+    });
   }
 
   updateAlarmStatusToTrue(alarmNo: number) {

--- a/src/inventory/inventory.service.ts
+++ b/src/inventory/inventory.service.ts
@@ -79,7 +79,7 @@ export class InventoryService {
     }
 
     try {
-      const [, result] = await this.prisma.$transaction([
+      const [, , result] = await this.prisma.$transaction([
         this.legendsRepository.updateOneLegendByUserNo(userNo, {
           itemCount: { increment: 1 },
         }),

--- a/src/posts/posts-swagger/create-one-post.decorator.ts
+++ b/src/posts/posts-swagger/create-one-post.decorator.ts
@@ -27,14 +27,20 @@ export function ApiCreateOnePost() {
       content: {
         JSON: {
           example: {
-            no: 8,
-            senderNo: 1,
-            receiverNo: 2,
+            no: 19,
             content: "김뿡우",
-            createdAt: "2024-07-14T11:50:55.000Z",
+            createdAt: "2024-07-28T09:39:52.000Z",
             check: false,
             senderDelete: false,
             receiverDelete: false,
+            userPostSenderNo: {
+              no: 31,
+              nickname: "쌉악질",
+            },
+            userPostReceiverNo: {
+              no: 1,
+              nickname: "1",
+            },
           },
         },
       },

--- a/src/posts/posts.module.ts
+++ b/src/posts/posts.module.ts
@@ -4,9 +4,10 @@ import { PostsController } from "./posts.controller";
 import { PostsRepository } from "./posts.repositroy";
 import { UsersModule } from "src/users/users.module";
 import { SseModule } from "src/sse/sse.module";
+import { AlarmsModule } from "src/alarms/alarms.module";
 
 @Module({
-  imports: [UsersModule, SseModule],
+  imports: [UsersModule, SseModule, AlarmsModule],
   controllers: [PostsController],
   providers: [PostsService, PostsRepository],
 })

--- a/src/posts/posts.module.ts
+++ b/src/posts/posts.module.ts
@@ -3,9 +3,10 @@ import { PostsService } from "./posts.service";
 import { PostsController } from "./posts.controller";
 import { PostsRepository } from "./posts.repositroy";
 import { UsersModule } from "src/users/users.module";
+import { SseModule } from "src/sse/sse.module";
 
 @Module({
-  imports: [UsersModule],
+  imports: [UsersModule, SseModule],
   controllers: [PostsController],
   providers: [PostsService, PostsRepository],
 })

--- a/src/posts/posts.repositroy.ts
+++ b/src/posts/posts.repositroy.ts
@@ -1,9 +1,31 @@
 import { Injectable } from "@nestjs/common";
 import { PrismaService } from "src/prisma/prisma.service";
+import { PrismaTxType } from "src/prisma/prisma.type";
 
 @Injectable()
 export class PostsRepository {
   constructor(private readonly prisma: PrismaService) {}
+
+  createOnePost(
+    senderNo: number,
+    receiverNo: number,
+    content: string,
+    tx?: PrismaTxType,
+  ) {
+    return (tx ?? this.prisma).post.create({
+      select: {
+        no: true,
+        content: true,
+        createdAt: true,
+        check: true,
+        senderDelete: true,
+        receiverDelete: true,
+        userPostSenderNo: { select: { no: true, nickname: true } },
+        userPostReceiverNo: { select: { no: true, nickname: true } },
+      },
+      data: { senderNo, receiverNo, content },
+    });
+  }
 
   getOnePost(postNo: number) {
     return this.prisma.post.findUnique({ where: { no: postNo } });

--- a/src/posts/posts.repositroy.ts
+++ b/src/posts/posts.repositroy.ts
@@ -1,12 +1,11 @@
 import { Injectable } from "@nestjs/common";
-import { PrismaPromise, post } from "@prisma/client";
 import { PrismaService } from "src/prisma/prisma.service";
 
 @Injectable()
 export class PostsRepository {
   constructor(private readonly prisma: PrismaService) {}
 
-  getOnePost(postNo: number): PrismaPromise<post> {
+  getOnePost(postNo: number) {
     return this.prisma.post.findUnique({ where: { no: postNo } });
   }
 
@@ -40,10 +39,6 @@ export class PostsRepository {
     });
   }
 
-  createOnePost(senderNo: number, receiverNo: number, content: string) {
-    return this.prisma.post.create({ data: { senderNo, receiverNo, content } });
-  }
-
   updateOnePostCheckToTrue(postNo: number) {
     return this.prisma.post.update({
       select: {
@@ -64,7 +59,7 @@ export class PostsRepository {
   updateOnePostToDeleteByUser(
     no: number,
     senderReceiverDeleteField: "senderDelete" | "receiverDelete",
-  ): PrismaPromise<post> {
+  ) {
     return this.prisma.post.update({
       data: { [senderReceiverDeleteField]: true },
       where: { no },

--- a/src/posts/posts.service.ts
+++ b/src/posts/posts.service.ts
@@ -112,6 +112,7 @@ export class PostsService {
           receiverNo,
           `${post.userPostSenderNo.nickname}님께서 쪽지를 보냈습니다.`,
           "쪽지",
+          tx,
         );
 
         return post;

--- a/src/posts/posts.service.ts
+++ b/src/posts/posts.service.ts
@@ -107,7 +107,7 @@ export class PostsService {
 
         await this.alarmsRepository.createOneAlarm(
           receiverNo,
-          `${post.userPostSenderNo.nickname}남께서 쪽지를 보냈습니다.`,
+          `${post.userPostSenderNo.nickname}님께서 쪽지를 보냈습니다.`,
           "쪽지",
         );
 
@@ -116,7 +116,7 @@ export class PostsService {
 
       this.sseService.sendSse(receiverNo, {
         title: "쪽지",
-        content: `${post.userPostSenderNo.nickname}남께서 쪽지를 보냈습니다.`,
+        content: `${post.userPostSenderNo.nickname}님께서 쪽지를 보냈습니다.`,
       });
 
       return post;

--- a/src/prisma/prisma.type.ts
+++ b/src/prisma/prisma.type.ts
@@ -1,0 +1,3 @@
+import { Prisma } from "@prisma/client";
+
+export type PrismaTxType = Prisma.TransactionClient;


### PR DESCRIPTION
## 관련 이슈

#96

## 개요

>알람 테이블에 알람 추가 및 sse 보내기 기능 추가 및 swagger 예시 소폭 수정

## 작업 상세 내용

- [ ] 쪽지 알람

## 참고 자료(선택)
- 프리즈마 공식문서ㄱ

## 하고싶은 말
Prisma에는 transaction 방식이 2가지가 있습니다.
하나는 batch방식이고
다른 하나는 interactive 방식 입니다.
batch 와 interative의 차이점은 유연성에 있습니다.
batch(일괄)의 경우 :
```javascript
const [user, item] = await this.prisma.$transaction([

this.userRepository.createOneUser(...),

this.inventoryRepository.createOneItem(...)
], "option");
```

정말 명시적이게도 배열 내부에 prisma 관련 메서드를 넣어서 구현합니다.
당연하지만 하나라도 실패하면 원상복구 되고요.

interactive(상호작용)의 경우 : 
```javascript
const user = await this.prisma.$transaction(async (tx) => {

if(...) {

const a = await tx.user.update(...);

return a;
}

const a = await tx.user.update(...);

return a;
}, "option")

return user;
```
interactive는 이런식으로 중간에 로직을 섞어 넣을수 있습니다.
<~~이번 같은 경우는 user의 nickname을 추출해 내기 위해서 interactive trasacion을 구현했고
때문에 Repository에 있었던 기존의 post 생성 로직은 삭제 했습니다.
이로써 Repository에 대한 존재의의가 위협받게 됐는데 좋은 의견 있으면 말씀해 주시죠.~~>

해당 부분 tx객체를 받아서 Repo에서 해결하는것으로 구현했습니다. @hobiJeong 매번 감사합니다.