### PR TITLE
Feature/#69/logout

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -19,6 +19,7 @@ import { CookieInterceptor } from "./interceptors/cookie.interceptor";
 import { ApiKakaoLogout } from "./swagger-decorators/kakao-logout-decorator";
 import { ApiNaverLogout } from "./swagger-decorators/naver-logout-decorator";
 import { ApiKakaoUnlink } from "./swagger-decorators/kakao-unlink-decorator";
+import { ApiNaverUnlink } from "./swagger-decorators/naver-unlink-decorator";
 
 @Controller("auth")
 export class AuthController {
@@ -66,10 +67,18 @@ export class AuthController {
   async naverLogout(@UserNo() userNo: number) {
     return await this.authService.naverLogout(userNo);
   }
+
   @ApiKakaoUnlink()
   @UseGuards(AccessTokenAuthGuard)
   @Delete("kakao/unlink")
   async kakaoUnlink(@UserNo() userNo: number) {
     return await this.authService.kakaoUnlink(userNo);
+  }
+
+  @ApiNaverUnlink()
+  @UseGuards(AccessTokenAuthGuard)
+  @Delete("naver/unlink")
+  async naverUnlink(@UserNo() userNo: number) {
+    return await this.authService.naverUnlink(userNo);
   }
 }

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -10,7 +10,7 @@ import {
 } from "@nestjs/common";
 import { AuthService } from "./services/auth.service";
 import { AccessTokenAuthGuard, RefreshTokenAuthGuard } from "./jwt/jwt.guard";
-import { userNo } from "./auth.decorator";
+import { UserNo } from "./auth.decorator";
 import { TokenService } from "./services/token.service";
 import { ApiNaverLogin } from "./swagger-decorators/naver-login-decorator";
 import { ApiKakaoLogin } from "./swagger-decorators/kakao-login-decorator";
@@ -18,6 +18,7 @@ import { ApiNewAccessToken } from "./swagger-decorators/new-access-token.decorat
 import { CookieInterceptor } from "./interceptors/cookie.interceptor";
 import { ApiKakaoLogout } from "./swagger-decorators/kakao-logout-decorator";
 import { ApiNaverLogout } from "./swagger-decorators/naver-logout-decorator";
+import { ApiKakaoUnlink } from "./swagger-decorators/kakao-unlink-decorator";
 
 @Controller("auth")
 export class AuthController {
@@ -48,21 +49,27 @@ export class AuthController {
   @ApiNewAccessToken()
   @UseGuards(RefreshTokenAuthGuard)
   @Get("new-access-token")
-  async newAccessToken(@userNo() userNo: number) {
+  async newAccessToken(@UserNo() userNo: number) {
     return await this.tokenService.createNewAccessToken(userNo);
   }
 
   @ApiKakaoLogout()
   @UseGuards(AccessTokenAuthGuard)
   @Delete("kakao/logout")
-  async kakaoLogout(@userNo() userNo: number) {
+  async kakaoLogout(@UserNo() userNo: number) {
     return await this.authService.kakaoLogout(userNo);
   }
 
   @ApiNaverLogout()
   @UseGuards(AccessTokenAuthGuard)
   @Delete("naver/logout")
-  async naverLogout(@userNo() userNo: number) {
+  async naverLogout(@UserNo() userNo: number) {
     return await this.authService.naverLogout(userNo);
+  }
+  @ApiKakaoUnlink()
+  @UseGuards(AccessTokenAuthGuard)
+  @Delete("kakao/unlink")
+  async kakaoUnlink(@UserNo() userNo: number) {
+    return await this.authService.kakaoUnlink(userNo);
   }
 }

--- a/src/auth/auth.decorator.ts
+++ b/src/auth/auth.decorator.ts
@@ -1,6 +1,6 @@
 import { createParamDecorator, ExecutionContext } from "@nestjs/common";
 
-export const userNo = createParamDecorator(
+export const UserNo = createParamDecorator(
   (data: unknown, ctx: ExecutionContext) => {
     const request = ctx.switchToHttp().getRequest();
     return request.user.no;

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -7,9 +7,10 @@ import { TokenRepository } from "./repositories/token.repository";
 import { JwtModule } from "@nestjs/jwt";
 import { AccessStrategy, RefreshStrategy } from "./jwt/jwt.strategy";
 import { RedisModule } from "./redis/redis.module";
+import { LegendsModule } from "src/legends/legends.module";
 
 @Module({
-  imports: [UsersModule, JwtModule, RedisModule],
+  imports: [UsersModule, JwtModule, RedisModule, LegendsModule],
   controllers: [AuthController],
   providers: [
     AuthService,

--- a/src/auth/jwt/jwt.guard.ts
+++ b/src/auth/jwt/jwt.guard.ts
@@ -6,6 +6,7 @@ import {
   NotFoundException,
   UnauthorizedException,
   Logger,
+  ConflictException,
 } from "@nestjs/common";
 import { AuthGuard } from "@nestjs/passport";
 import { Observable } from "rxjs";
@@ -57,7 +58,7 @@ export class AccessTokenAuthGuard extends AuthGuard("accessToken") {
         throw new NotFoundException(error.message);
       }
       if (error.message === "token is not matched.") {
-        throw new NotFoundException(error.message);
+        throw new ConflictException(error.message);
       } else {
         this.logger.error(error);
         throw new UnauthorizedException("jwt error");
@@ -111,6 +112,9 @@ export class RefreshTokenAuthGuard extends AuthGuard("refreshToken") {
       }
       if (error.message === "Token not found.") {
         throw new NotFoundException(error.message);
+      }
+      if (error.message === "token is not matched.") {
+        throw new ConflictException(error.message);
       } else {
         this.logger.error(error);
         throw new UnauthorizedException("jwt error");

--- a/src/auth/jwt/jwt.strategy.ts
+++ b/src/auth/jwt/jwt.strategy.ts
@@ -1,5 +1,6 @@
 import {
   BadRequestException,
+  ConflictException,
   Injectable,
   NotFoundException,
 } from "@nestjs/common";
@@ -43,7 +44,7 @@ export class AccessStrategy extends PassportStrategy(Strategy, "accessToken") {
     }
 
     if (tokenFromRequest !== tokenFromRedis) {
-      throw new NotFoundException("token is not matched.");
+      throw new ConflictException("token is not matched.");
     }
     return { tokenType: payload.sub, no: payload.userNo };
   }
@@ -88,7 +89,7 @@ export class RefreshStrategy extends PassportStrategy(
     }
 
     if (tokenFromRequest !== tokenFromRedis) {
-      throw new NotFoundException("token is not matched.");
+      throw new ConflictException("token is not matched.");
     }
 
     return { tokenType: payload.sub, no: payload.userNo };

--- a/src/auth/repositories/token.repository.ts
+++ b/src/auth/repositories/token.repository.ts
@@ -20,7 +20,7 @@ export class TokenRepository {
   }
 
   async findToken(userNo: number) {
-    return this.prisma.token.findMany({
+    return this.prisma.token.findUnique({
       where: {
         userNo,
       },
@@ -28,7 +28,7 @@ export class TokenRepository {
   }
 
   async deleteTokens(userNo: number) {
-    return this.prisma.token.deleteMany({
+    return this.prisma.token.delete({
       where: {
         userNo,
       },
@@ -36,7 +36,7 @@ export class TokenRepository {
   }
 
   async updateAccessToken(userNo: number, socialAccess: string) {
-    return this.prisma.token.updateMany({
+    return this.prisma.token.update({
       where: {
         userNo,
       },
@@ -51,7 +51,7 @@ export class TokenRepository {
     socialAccess: string,
     socialRefresh: string,
   ) {
-    return this.prisma.token.updateMany({
+    return this.prisma.token.update({
       where: {
         userNo,
       },

--- a/src/auth/services/auth.service.ts
+++ b/src/auth/services/auth.service.ts
@@ -97,6 +97,8 @@ export class AuthService {
         await this.legendsRepository.createUserLegend(user.no);
       }
 
+      await this.usersRepository.updateUserDeletedAt(user.no);
+
       const accessToken = this.tokenService.createAccessToken(user.no);
       const refreshToken = this.tokenService.createRefreshToken(user.no);
 
@@ -214,6 +216,8 @@ export class AuthService {
         );
         await this.legendsRepository.createUserLegend(user.no);
       }
+
+      await this.usersRepository.updateUserDeletedAt(user.no);
 
       const accessToken = this.tokenService.createAccessToken(user.no);
       const refreshToken = this.tokenService.createRefreshToken(user.no);

--- a/src/auth/services/auth.service.ts
+++ b/src/auth/services/auth.service.ts
@@ -97,13 +97,13 @@ export class AuthService {
         await this.legendsRepository.createUserLegend(user.no);
       }
 
-      await this.usersRepository.updateUserDeletedAt(user.no);
+      await this.usersRepository.updateDeleteAt(user.no, null);
 
       const accessToken = this.tokenService.createAccessToken(user.no);
       const refreshToken = this.tokenService.createRefreshToken(user.no);
 
       const socialTokens = await this.tokenRepository.findToken(user.no);
-      if (socialTokens[0] === undefined) {
+      if (!socialTokens) {
         await this.tokenRepository.saveTokens(
           user.no,
           socialAccessToken,
@@ -217,13 +217,13 @@ export class AuthService {
         await this.legendsRepository.createUserLegend(user.no);
       }
 
-      await this.usersRepository.updateUserDeletedAt(user.no);
+      await this.usersRepository.updateDeleteAt(user.no, null);
 
       const accessToken = this.tokenService.createAccessToken(user.no);
       const refreshToken = this.tokenService.createRefreshToken(user.no);
 
       const socialTokens = await this.tokenRepository.findToken(user.no);
-      if (socialTokens[0] === undefined) {
+      if (!socialTokens) {
         await this.tokenRepository.saveTokens(
           user.no,
           socialAccessToken,
@@ -303,7 +303,7 @@ export class AuthService {
   async kakaoLogout(userNo: number) {
     try {
       const socialTokens = await this.tokenRepository.findToken(userNo);
-      if (socialTokens[0] === undefined) {
+      if (!socialTokens) {
         throw new NotFoundException("user not found");
       }
       const user = await this.usersRepository.findUserByUserNo(userNo);
@@ -313,8 +313,8 @@ export class AuthService {
         );
       }
 
-      let socialAccessToken = socialTokens[0].socialAccess;
-      const socialRefreshToken = socialTokens[0].socialRefresh;
+      let socialAccessToken = socialTokens.socialAccess;
+      const socialRefreshToken = socialTokens.socialRefresh;
 
       const socialAccessTokenInfo =
         await this.tokenService.kakaoSocialAccessTokenInfo(socialAccessToken);
@@ -364,12 +364,12 @@ export class AuthService {
   async naverUnlink(userNo: number) {
     try {
       const socialTokens = await this.tokenRepository.findToken(userNo);
-      if (socialTokens[0] === undefined) {
+      if (!socialTokens) {
         throw new NotFoundException("token not found");
       }
 
-      let socialAccessToken = socialTokens[0].socialAccess;
-      const socialRefreshToken = socialTokens[0].socialRefresh;
+      let socialAccessToken = socialTokens.socialAccess;
+      const socialRefreshToken = socialTokens.socialRefresh;
 
       const user = await this.usersRepository.findUserByUserNo(userNo);
       if (!user) {
@@ -417,7 +417,7 @@ export class AuthService {
         userNo.toString() + "-accessToken",
       );
 
-      await this.usersRepository.softDeleteUser(userNo);
+      await this.usersRepository.updateDeleteAt(userNo, new Date());
 
       return { message: "네이버 회원 탈퇴 성공" };
     } catch (error) {
@@ -437,7 +437,7 @@ export class AuthService {
   async kakaoUnlink(userNo: number) {
     try {
       const socialTokens = await this.tokenRepository.findToken(userNo);
-      if (socialTokens[0] === undefined) {
+      if (!socialTokens) {
         throw new NotFoundException("user not found");
       }
       const user = await this.usersRepository.findUserByUserNo(userNo);
@@ -446,8 +446,8 @@ export class AuthService {
           "You are not a user logged in with Kakao.",
         );
       }
-      let socialAccessToken = socialTokens[0].socialAccess;
-      const socialRefreshToken = socialTokens[0].socialRefresh;
+      let socialAccessToken = socialTokens.socialAccess;
+      const socialRefreshToken = socialTokens.socialRefresh;
 
       const socialAccessTokenInfo =
         await this.tokenService.kakaoSocialAccessTokenInfo(socialAccessToken);
@@ -481,7 +481,7 @@ export class AuthService {
         userNo.toString() + "-accessToken",
       );
 
-      await this.usersRepository.softDeleteUser(userNo);
+      await this.usersRepository.updateDeleteAt(userNo, new Date());
 
       return { message: "카카오 탈퇴 성공" };
     } catch (error) {

--- a/src/auth/services/auth.service.ts
+++ b/src/auth/services/auth.service.ts
@@ -11,6 +11,7 @@ import { UsersRepository } from "src/users/users.repository";
 import { TokenService } from "src/auth/services/token.service";
 import { TokenRepository } from "src/auth/repositories/token.repository";
 import { ConfigService } from "@nestjs/config";
+import { LegendsRepository } from "src/legends/legends.repository";
 
 @Injectable()
 export class AuthService {
@@ -29,6 +30,7 @@ export class AuthService {
     private readonly tokenRepository: TokenRepository,
     private readonly logger: Logger,
     private readonly configService: ConfigService,
+    private readonly legendsRepository: LegendsRepository,
   ) {}
 
   async naverLogin(authorizeCode: string) {
@@ -92,6 +94,7 @@ export class AuthService {
           userInfo.response.profile_image,
           "naver",
         );
+        // await this.legendsRepository.
       }
 
       const accessToken = this.tokenService.createAccessToken(user.no);
@@ -351,6 +354,79 @@ export class AuthService {
       }
     }
     return { message: "카카오 로그아웃 성공" };
+  }
+
+  async naverUnlink(userNo: number) {
+    try {
+      const socialTokens = await this.tokenRepository.findToken(userNo);
+      if (socialTokens[0] === undefined) {
+        throw new NotFoundException("token not found");
+      }
+
+      let socialAccessToken = socialTokens[0].socialAccess;
+      const socialRefreshToken = socialTokens[0].socialRefresh;
+
+      const user = await this.usersRepository.findUserByUserNo(userNo);
+      if (!user) {
+        throw new NotFoundException("user not found");
+      }
+      if (user.domain !== "naver") {
+        throw new UnauthorizedException(
+          "You are not a user logged in with Naver.",
+        );
+      }
+      const socialAccessTokenInfo =
+        await this.tokenService.naverSocialAccessTokenInfo(socialAccessToken);
+
+      if (socialAccessTokenInfo === 401) {
+        const newNaverAccessToken =
+          await this.tokenService.createNewNaverAccessToken(socialRefreshToken);
+        await this.tokenRepository.updateAccessToken(
+          userNo,
+          newNaverAccessToken.access_token,
+        );
+        socialAccessToken = newNaverAccessToken.access_token;
+      }
+      const naverUnlinkUrl = "https://nid.naver.com/oauth2.0/token";
+      const naverUnlinkData = {
+        grant_type: "delete",
+        client_id: this.configService.get<string>("NAVER_CLIENT_ID"),
+        client_secret: this.configService.get<string>("NAVER_CLIENT_SECRET"),
+        access_token: socialAccessToken,
+      };
+      const userUnlink = (
+        await axios.get(naverUnlinkUrl, {
+          params: naverUnlinkData,
+        })
+      ).data;
+
+      if (userUnlink.result !== "success") {
+        throw new UnauthorizedException(userUnlink.error_description);
+      }
+
+      await this.tokenRepository.deleteTokens(userNo);
+      await this.tokenService.delRefreshToken(
+        userNo.toString() + "-refreshToken",
+      );
+      await this.tokenService.delAccessToken(
+        userNo.toString() + "-accessToken",
+      );
+
+      await this.usersRepository.softDeleteUser(userNo);
+
+      return { message: "네이버 회원 탈퇴 성공" };
+    } catch (error) {
+      if (error.response.statusCode === 401) {
+        throw new UnauthorizedException(error.response.message);
+      } else if (error.response.statusCode === 404) {
+        throw new NotFoundException(error.response.message);
+      } else {
+        this.logger.error(error);
+        throw new InternalServerErrorException(
+          "회원탈퇴 중 서버에러가 발생했습니다.",
+        );
+      }
+    }
   }
 
   async kakaoUnlink(userNo: number) {

--- a/src/auth/services/auth.service.ts
+++ b/src/auth/services/auth.service.ts
@@ -94,7 +94,7 @@ export class AuthService {
           userInfo.response.profile_image,
           "naver",
         );
-        // await this.legendsRepository.
+        await this.legendsRepository.createUserLegend(user.no);
       }
 
       const accessToken = this.tokenService.createAccessToken(user.no);
@@ -212,6 +212,7 @@ export class AuthService {
           userProperties.profile_image,
           "kakao",
         );
+        await this.legendsRepository.createUserLegend(user.no);
       }
 
       const accessToken = this.tokenService.createAccessToken(user.no);

--- a/src/auth/services/token.service.ts
+++ b/src/auth/services/token.service.ts
@@ -52,10 +52,11 @@ export class TokenService {
         client_secret: this.configService.get<string>("NAVER_CLIENT_SECRET"),
         refresh_token: socialRefreshToken,
       };
-      return (await axios.get(naverTokenUrl, {
-        params: naverTokenData,
-      })).data;
-
+      return (
+        await axios.get(naverTokenUrl, {
+          params: naverTokenData,
+        })
+      ).data;
     } catch (error) {
       this.logger.error(error);
       throw new InternalServerErrorException(
@@ -97,7 +98,6 @@ export class TokenService {
         },
       };
       const response = await axios.get(naverTokenInfoUrl, naverTokenInfoHeader);
-      // console.log(response);
       return response.data;
     } catch (error) {
       if (error.response.data.resultcode === "024") {

--- a/src/auth/swagger-decorators/kakao-unlink-decorator.ts
+++ b/src/auth/swagger-decorators/kakao-unlink-decorator.ts
@@ -1,0 +1,169 @@
+import { applyDecorators } from "@nestjs/common";
+import {
+  ApiBearerAuth,
+  ApiHeaders,
+  ApiOperation,
+  ApiResponse,
+} from "@nestjs/swagger";
+
+export function ApiKakaoUnlink() {
+  return applyDecorators(
+    ApiOperation({
+      summary: "카카오 회원탈퇴 API",
+      description: "카카오 회원탈퇴 API",
+    }),
+    ApiResponse({
+      status: 200,
+      description: "성공적으로 회원탈퇴가 된 경우",
+      content: {
+        JSON: { example: { message: "카카오 회원탈퇴 성공." } },
+      },
+    }),
+    ApiResponse({
+      status: 400,
+      description: "400 error",
+      content: {
+        JSON: {
+          examples: {
+            "Authorization header is missing.": {
+              value: {
+                message: "Authorization header is missing.",
+                error: "Bad Request",
+                statusCode: 400,
+              },
+              description: "헤더에 액세스 토큰이 없는 경우",
+            },
+            "not access token type": {
+              value: {
+                message: "not access token type",
+                error: "Bad Request",
+                statusCode: 400,
+              },
+              description: "토큰 타입이 액세스 토큰이 아닌 경우",
+            },
+            "jwt must be provided": {
+              value: {
+                message: "jwt must be provided",
+                error: "Bad Request",
+                statusCode: 400,
+              },
+              description: "토큰이 제공되지 않은 경우",
+            },
+          },
+        },
+      },
+    }),
+    ApiResponse({
+      status: 401,
+      description: "401 error",
+      content: {
+        JSON: {
+          examples: {
+            "invalid token": {
+              value: {
+                message: "invalid token",
+                error: "Unauthorized",
+                statusCode: 401,
+              },
+              description: "유효하지 않은 토큰인 경우",
+            },
+            "incorrect token": {
+              value: {
+                message: "incorrect token",
+                error: "Unauthorized",
+                statusCode: 401,
+              },
+              description: "우리 서비스의 토큰이 아닌 경우",
+            },
+            "jwt expired": {
+              value: {
+                message: "jwt expired",
+                error: "Unauthorized",
+                statusCode: 401,
+              },
+              description: "만료된 토큰인 경우",
+            },
+            "You are not a user logged in with Kakao.": {
+              value: {
+                message: "You are not a user logged in with Kakao.",
+                error: "Unauthorized",
+                statusCode: 401,
+              },
+              description: "카카오로 로그인한 유저가 아닌 경우",
+            },
+            "jwt error": {
+              value: {
+                message: "jwt error",
+                error: "Unauthorized",
+                statusCode: 401,
+              },
+              description: "그 외 에러 (안진우에게 연락주세요..ㅎ)",
+            },
+          },
+        },
+      },
+    }),
+    ApiResponse({
+      status: 404,
+      description: "404 error",
+      content: {
+        JSON: {
+          examples: {
+            "Token not found.": {
+              value: {
+                message: "Token not found.",
+                error: "Not Found",
+                statusCode: 404,
+              },
+              description: "액세스 토큰이 Redis에 없는 경우",
+            },
+            "token is not matched.": {
+              value: {
+                message: "token is not matched.",
+                error: "Not Found",
+                statusCode: 404,
+              },
+              description:
+                "요청한 토큰과 Redis에 저장된 토큰이 일치하지 않는 경우",
+            },
+            "user not found": {
+              value: {
+                message: "user not found",
+                error: "Not Found",
+                statusCode: 404,
+              },
+              description: "유저를 찾을 수 없는 경우",
+            },
+          },
+        },
+      },
+    }),
+    ApiResponse({
+      status: 409,
+      description: "요청한 유저와 db에 저장된 유저가 일치하지 않는 경우",
+      content: {
+        JSON: {
+          example: {
+            message: "Invalid user",
+            error: "Conflict",
+            statusCode: 409,
+          },
+        },
+      },
+    }),
+    ApiResponse({
+      status: 500,
+      description: "Internal server error",
+      content: {
+        JSON: {
+          example: {
+            message: "로그아웃 중 서버에러가 발생했습니다.",
+            error: "Internal Server Error",
+            statusCode: 500,
+          },
+        },
+      },
+    }),
+    ApiBearerAuth("access-token"),
+  );
+}

--- a/src/auth/swagger-decorators/kakao-unlink-decorator.ts
+++ b/src/auth/swagger-decorators/kakao-unlink-decorator.ts
@@ -117,15 +117,6 @@ export function ApiKakaoUnlink() {
               },
               description: "액세스 토큰이 Redis에 없는 경우",
             },
-            "token is not matched.": {
-              value: {
-                message: "token is not matched.",
-                error: "Not Found",
-                statusCode: 404,
-              },
-              description:
-                "요청한 토큰과 Redis에 저장된 토큰이 일치하지 않는 경우",
-            },
             "user not found": {
               value: {
                 message: "user not found",
@@ -140,13 +131,29 @@ export function ApiKakaoUnlink() {
     }),
     ApiResponse({
       status: 409,
-      description: "요청한 유저와 db에 저장된 유저가 일치하지 않는 경우",
+      description: "409 error",
       content: {
         JSON: {
-          example: {
-            message: "Invalid user",
-            error: "Conflict",
-            statusCode: 409,
+          examples: {
+            "token is not matched.": {
+              value: {
+                message: "token is not matched.",
+                error: "Conflict",
+                statusCode: 409,
+              },
+              description:
+                "요청한 토큰과 Redis에 저장된 토큰이 일치하지 않는 경우",
+            },
+
+            "Invalid user": {
+              value: {
+                message: "Invalid user",
+                error: "Conflict",
+                statusCode: 409,
+              },
+              description:
+                "요청한 유저와 db에 저장된 유저가 일치하지 않는 경우",
+            },
           },
         },
       },

--- a/src/auth/swagger-decorators/naver-unlink-decorator.ts
+++ b/src/auth/swagger-decorators/naver-unlink-decorator.ts
@@ -1,0 +1,157 @@
+import { applyDecorators } from "@nestjs/common";
+import {
+  ApiBearerAuth,
+  ApiHeaders,
+  ApiOperation,
+  ApiResponse,
+} from "@nestjs/swagger";
+
+export function ApiNaverUnlink() {
+  return applyDecorators(
+    ApiOperation({
+      summary: "네이버 회원탈퇴 API",
+      description: "네이버 회원탈퇴 API",
+    }),
+    ApiResponse({
+      status: 200,
+      description: "성공적으로 회원탈퇴가 된 경우",
+      content: {
+        JSON: { example: { message: "네이버 회원탈퇴 성공." } },
+      },
+    }),
+    ApiResponse({
+      status: 400,
+      description: "400 error",
+      content: {
+        JSON: {
+          examples: {
+            "Authorization header is missing.": {
+              value: {
+                message: "Authorization header is missing.",
+                error: "Bad Request",
+                statusCode: 400,
+              },
+              description: "헤더에 액세스 토큰이 없는 경우",
+            },
+            "not access token type": {
+              value: {
+                message: "not access token type",
+                error: "Bad Request",
+                statusCode: 400,
+              },
+              description: "토큰 타입이 액세스 토큰이 아닌 경우",
+            },
+            "jwt must be provided": {
+              value: {
+                message: "jwt must be provided",
+                error: "Bad Request",
+                statusCode: 400,
+              },
+              description: "토큰이 제공되지 않은 경우",
+            },
+          },
+        },
+      },
+    }),
+    ApiResponse({
+      status: 401,
+      description: "401 error",
+      content: {
+        JSON: {
+          examples: {
+            "invalid token": {
+              value: {
+                message: "invalid token",
+                error: "Unauthorized",
+                statusCode: 401,
+              },
+              description: "유효하지 않은 토큰인 경우",
+            },
+            "incorrect token": {
+              value: {
+                message: "incorrect token",
+                error: "Unauthorized",
+                statusCode: 401,
+              },
+              description: "우리 서비스의 토큰이 아닌 경우",
+            },
+            "jwt expired": {
+              value: {
+                message: "jwt expired",
+                error: "Unauthorized",
+                statusCode: 401,
+              },
+              description: "만료된 토큰인 경우",
+            },
+            "You are not a user logged in with Naver.": {
+              value: {
+                message: "You are not a user logged in with Naver.",
+                error: "Unauthorized",
+                statusCode: 401,
+              },
+              description: "네이버로 로그인한 유저가 아닌 경우",
+            },
+            "jwt error": {
+              value: {
+                message: "jwt error",
+                error: "Unauthorized",
+                statusCode: 401,
+              },
+              description: "그 외 에러 (안진우에게 연락주세요..ㅎ)",
+            },
+          },
+        },
+      },
+    }),
+    ApiResponse({
+      status: 404,
+      description: "404 error",
+      content: {
+        JSON: {
+          examples: {
+            "Token not found.": {
+              value: {
+                message: "Token not found.",
+                error: "Not Found",
+                statusCode: 404,
+              },
+              description: "액세스 토큰이 Redis에 없는 경우",
+            },
+            "token is not matched.": {
+              value: {
+                message: "token is not matched.",
+                error: "Not Found",
+                statusCode: 404,
+              },
+              description:
+                "요청한 토큰과 Redis에 저장된 토큰이 일치하지 않는 경우",
+            },
+            "user not found": {
+              value: {
+                message: "user not found",
+                error: "Not Found",
+                statusCode: 404,
+              },
+              description: "유저를 찾을 수 없는 경우",
+            },
+          },
+        },
+      },
+    }),
+
+    ApiResponse({
+      status: 500,
+      description: "Internal server error",
+      content: {
+        JSON: {
+          example: {
+            message: "로그아웃 중 서버에러가 발생했습니다.",
+            error: "Internal Server Error",
+            statusCode: 500,
+          },
+        },
+      },
+    }),
+    ApiBearerAuth("access-token"),
+  );
+}

--- a/src/auth/swagger-decorators/naver-unlink-decorator.ts
+++ b/src/auth/swagger-decorators/naver-unlink-decorator.ts
@@ -138,6 +138,25 @@ export function ApiNaverUnlink() {
         },
       },
     }),
+    ApiResponse({
+      status: 409,
+      description: "409 error",
+      content: {
+        JSON: {
+          examples: {
+            "token is not matched.": {
+              value: {
+                message: "token is not matched.",
+                error: "Conflict",
+                statusCode: 409,
+              },
+              description:
+                "요청한 토큰과 Redis에 저장된 토큰이 일치하지 않는 경우",
+            },
+          },
+        },
+      },
+    }),
 
     ApiResponse({
       status: 500,

--- a/src/users/users.repository.ts
+++ b/src/users/users.repository.ts
@@ -15,16 +15,9 @@ export class UsersRepository {
     });
   }
 
-  softDeleteUser(userNo: number) {
+  updateDeleteAt(userNo: number, deletedAt: Date | null) {
     return this.prisma.user.update({
-      data: { deletedAt: new Date() },
-      where: { no: userNo },
-    });
-  }
-
-  updateUserDeletedAt(userNo: number) {
-    return this.prisma.user.update({
-      data: { deletedAt: null },
+      data: { deletedAt },
       where: { no: userNo },
     });
   }

--- a/src/users/users.repository.ts
+++ b/src/users/users.repository.ts
@@ -22,6 +22,13 @@ export class UsersRepository {
     });
   }
 
+  updateUserDeletedAt(userNo: number) {
+    return this.prisma.user.update({
+      data: { deletedAt: null },
+      where: { no: userNo },
+    });
+  }
+
   createUser(
     uniqueIdentifier: string,
     socialName: string,

--- a/src/users/users.repository.ts
+++ b/src/users/users.repository.ts
@@ -14,6 +14,13 @@ export class UsersRepository {
     });
   }
 
+  softDeleteUser(userNo: number) {
+    return this.prisma.user.update({
+      data: { deletedAt: new Date() },
+      where: { no: userNo },
+    });
+  }
+
   createUser(
     uniqueIdentifier: string,
     socialName: string,


### PR DESCRIPTION
## 관련 이슈

#69 

## 개요

> 카카오, 네이버 회원 탈퇴 로직과 신규 유저 가입 시 createUserLegend를 통해서 기록용 테이블에 저장, 로그인 시 deletedAt null로 초기화됩니다. 소셜 액세스 토큰은 만료시에 db에 존재하는 소셜 리프레시 토큰으로 소셜 액세스 토큰을 재발급 후 회원 탈퇴가 진행됩니다. 

## 작업 상세 내용

- [x] 카카오 회원 탈퇴
- [x] 네이버 회원 탈퇴
- [x] 로그인 modify

