### PR TITLE
Feature/#69/logout

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -79,6 +79,12 @@ export class AuthController {
     return await this.authService.naverLogout(userNo);
   }
 
+  @UseGuards(AccessTokenAuthGuard)
+  @Delete("google/logout")
+  async googleLogout(@UserNo() userNo: number) {
+    return await this.authService.googleLogout(userNo);
+  }
+
   @ApiKakaoUnlink()
   @UseGuards(AccessTokenAuthGuard)
   @Delete("kakao/unlink")

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -21,6 +21,7 @@ import { ApiNaverLogout } from "./swagger-decorators/naver-logout-decorator";
 import { ApiKakaoUnlink } from "./swagger-decorators/kakao-unlink-decorator";
 import { ApiNaverUnlink } from "./swagger-decorators/naver-unlink-decorator";
 import { ApiGoogleLogin } from "./swagger-decorators/google-login-decorator";
+import { ApiGoogleLogout } from "./swagger-decorators/google-logout-decorator";
 
 @Controller("auth")
 export class AuthController {
@@ -79,6 +80,7 @@ export class AuthController {
     return await this.authService.naverLogout(userNo);
   }
 
+  @ApiGoogleLogout()
   @UseGuards(AccessTokenAuthGuard)
   @Delete("google/logout")
   async googleLogout(@UserNo() userNo: number) {

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -22,6 +22,7 @@ import { ApiKakaoUnlink } from "./swagger-decorators/kakao-unlink-decorator";
 import { ApiNaverUnlink } from "./swagger-decorators/naver-unlink-decorator";
 import { ApiGoogleLogin } from "./swagger-decorators/google-login-decorator";
 import { ApiGoogleLogout } from "./swagger-decorators/google-logout-decorator";
+import { ApiGoogleUnlink } from "./swagger-decorators/google-unlink-decorator";
 
 @Controller("auth")
 export class AuthController {
@@ -99,5 +100,12 @@ export class AuthController {
   @Delete("naver/unlink")
   async naverUnlink(@UserNo() userNo: number) {
     return await this.authService.naverUnlink(userNo);
+  }
+
+  @ApiGoogleUnlink()
+  @UseGuards(AccessTokenAuthGuard)
+  @Delete("google/unlink")
+  async googleUnlink(@UserNo() userNo: number) {
+    return await this.authService.googleUnlink(userNo);
   }
 }

--- a/src/auth/services/auth.service.ts
+++ b/src/auth/services/auth.service.ts
@@ -12,7 +12,6 @@ import { TokenService } from "src/auth/services/token.service";
 import { TokenRepository } from "src/auth/repositories/token.repository";
 import { ConfigService } from "@nestjs/config";
 import { LegendsRepository } from "src/legends/legends.repository";
-import { access } from "fs";
 
 @Injectable()
 export class AuthService {

--- a/src/auth/services/auth.service.ts
+++ b/src/auth/services/auth.service.ts
@@ -677,7 +677,7 @@ export class AuthService {
         socialAccessToken = newGoogleAccessToken.access_token;
       }
 
-      const unlink = await axios.post(
+      await axios.post(
         `https://accounts.google.com/o/oauth2/revoke?token=${socialAccessToken}`,
         {},
         { headers: { "Content-type": "application/x-www-form-urlencoded" } },

--- a/src/auth/swagger-decorators/google-logout-decorator.ts
+++ b/src/auth/swagger-decorators/google-logout-decorator.ts
@@ -112,15 +112,7 @@ export function ApiGoogleLogout() {
               },
               description: "리프레시 토큰이 Redis에 없는 경우",
             },
-            "token is not matched.": {
-              value: {
-                message: "token is not matched.",
-                error: "Not Found",
-                statusCode: 404,
-              },
-              description:
-                "요청한 토큰과 Redis에 저장된 토큰이 일치하지 않는 경우",
-            },
+
             "user not found": {
               value: {
                 message: "user not found",
@@ -128,6 +120,25 @@ export function ApiGoogleLogout() {
                 statusCode: 404,
               },
               description: "유저를 찾을 수 없는 경우",
+            },
+          },
+        },
+      },
+    }),
+    ApiResponse({
+      status: 409,
+      description: "409 error",
+      content: {
+        JSON: {
+          examples: {
+            "token is not matched.": {
+              value: {
+                message: "token is not matched.",
+                error: "Conflict",
+                statusCode: 409,
+              },
+              description:
+                "요청한 토큰과 Redis에 저장된 토큰이 일치하지 않는 경우",
             },
           },
         },

--- a/src/auth/swagger-decorators/google-logout-decorator.ts
+++ b/src/auth/swagger-decorators/google-logout-decorator.ts
@@ -1,0 +1,151 @@
+import { applyDecorators } from "@nestjs/common";
+import { ApiBearerAuth, ApiOperation, ApiResponse } from "@nestjs/swagger";
+
+export function ApiGoogleLogout() {
+  return applyDecorators(
+    ApiOperation({
+      summary: "구글 로그아웃 API",
+      description: "구글 로그아웃 API",
+    }),
+    ApiResponse({
+      status: 200,
+      description: "성공적으로 로그아웃 된 경우",
+      content: {
+        JSON: { example: { message: "구글 로그아웃 성공." } },
+      },
+    }),
+    ApiResponse({
+      status: 400,
+      description: "400 error",
+      content: {
+        JSON: {
+          examples: {
+            "Authorization header is missing.": {
+              value: {
+                message: "Authorization header is missing.",
+                error: "Bad Request",
+                statusCode: 400,
+              },
+              description: "헤더에 액세스 토큰이 없는 경우",
+            },
+            "not access token type": {
+              value: {
+                message: "not access token type",
+                error: "Bad Request",
+                statusCode: 400,
+              },
+              description: "토큰 타입이 액세스 토큰이 아닌 경우",
+            },
+            "jwt must be provided": {
+              value: {
+                message: "jwt must be provided",
+                error: "Bad Request",
+                statusCode: 400,
+              },
+              description: "토큰이 제공되지 않은 경우",
+            },
+          },
+        },
+      },
+    }),
+    ApiResponse({
+      status: 401,
+      description: "401 error",
+      content: {
+        JSON: {
+          examples: {
+            "invalid token": {
+              value: {
+                message: "invalid token",
+                error: "Unauthorized",
+                statusCode: 401,
+              },
+              description: "유효하지 않은 토큰인 경우",
+            },
+            "incorrect token": {
+              value: {
+                message: "incorrect token",
+                error: "Unauthorized",
+                statusCode: 401,
+              },
+              description: "우리 서비스의 토큰이 아닌 경우",
+            },
+            "jwt expired": {
+              value: {
+                message: "jwt expired",
+                error: "Unauthorized",
+                statusCode: 401,
+              },
+              description: "만료된 토큰인 경우",
+            },
+            "You are not a user logged in with Naver": {
+              value: {
+                message: "You are not a user logged in with Naver.",
+                error: "Unauthorized",
+                statusCode: 401,
+              },
+              description: "구글로 로그인한 유저가 아닌 경우",
+            },
+            "jwt error": {
+              value: {
+                message: "jwt error",
+                error: "Unauthorized",
+                statusCode: 401,
+              },
+              description: "그 외 에러 (안진우에게 연락주세요..ㅎ)",
+            },
+          },
+        },
+      },
+    }),
+    ApiResponse({
+      status: 404,
+      description: "404 error",
+      content: {
+        JSON: {
+          examples: {
+            "Token not found.": {
+              value: {
+                message: "Token not found.",
+                error: "Not Found",
+                statusCode: 404,
+              },
+              description: "리프레시 토큰이 Redis에 없는 경우",
+            },
+            "token is not matched.": {
+              value: {
+                message: "token is not matched.",
+                error: "Not Found",
+                statusCode: 404,
+              },
+              description:
+                "요청한 토큰과 Redis에 저장된 토큰이 일치하지 않는 경우",
+            },
+            "user not found": {
+              value: {
+                message: "user not found",
+                error: "Not Found",
+                statusCode: 404,
+              },
+              description: "유저를 찾을 수 없는 경우",
+            },
+          },
+        },
+      },
+    }),
+    ApiResponse({
+      status: 500,
+      description: "Internal server error",
+      content: {
+        JSON: {
+          example: {
+            message: "로그아웃 중 서버에러가 발생했습니다.",
+            error: "Internal Server Error",
+            statusCode: 500,
+          },
+        },
+      },
+    }),
+    ApiBearerAuth("access-token"),
+  );
+}

--- a/src/auth/swagger-decorators/google-unlink-decorator.ts
+++ b/src/auth/swagger-decorators/google-unlink-decorator.ts
@@ -1,17 +1,17 @@
 import { applyDecorators } from "@nestjs/common";
 import { ApiBearerAuth, ApiOperation, ApiResponse } from "@nestjs/swagger";
 
-export function ApiGoogleLogout() {
+export function ApiGoogleUnlink() {
   return applyDecorators(
     ApiOperation({
-      summary: "구글 로그아웃 API",
-      description: "구글 로그아웃 API",
+      summary: "구글 회원탈퇴 API",
+      description: "구글 회원탈퇴 API",
     }),
     ApiResponse({
       status: 200,
-      description: "성공적으로 로그아웃 된 경우",
+      description: "성공적으로 회원탈퇴가 된 경우",
       content: {
-        JSON: { example: { message: "구글 로그아웃 성공." } },
+        JSON: { example: { message: "구글 회원탈퇴 성공." } },
       },
     }),
     ApiResponse({
@@ -78,7 +78,7 @@ export function ApiGoogleLogout() {
               },
               description: "만료된 토큰인 경우",
             },
-            "You are not a user logged in with Google": {
+            "You are not a user logged in with Google.": {
               value: {
                 message: "You are not a user logged in with Google.",
                 error: "Unauthorized",
@@ -110,7 +110,7 @@ export function ApiGoogleLogout() {
                 error: "Not Found",
                 statusCode: 404,
               },
-              description: "리프레시 토큰이 Redis에 없는 경우",
+              description: "액세스 토큰이 Redis에 없는 경우",
             },
             "token is not matched.": {
               value: {
@@ -133,6 +133,26 @@ export function ApiGoogleLogout() {
         },
       },
     }),
+    ApiResponse({
+      status: 409,
+      description: "409 error",
+      content: {
+        JSON: {
+          examples: {
+            "token is not matched.": {
+              value: {
+                message: "token is not matched.",
+                error: "Conflict",
+                statusCode: 409,
+              },
+              description:
+                "요청한 토큰과 Redis에 저장된 토큰이 일치하지 않는 경우",
+            },
+          },
+        },
+      },
+    }),
+
     ApiResponse({
       status: 500,
       description: "Internal server error",

--- a/src/auth/swagger-decorators/google-unlink-decorator.ts
+++ b/src/auth/swagger-decorators/google-unlink-decorator.ts
@@ -112,15 +112,6 @@ export function ApiGoogleUnlink() {
               },
               description: "액세스 토큰이 Redis에 없는 경우",
             },
-            "token is not matched.": {
-              value: {
-                message: "token is not matched.",
-                error: "Not Found",
-                statusCode: 404,
-              },
-              description:
-                "요청한 토큰과 Redis에 저장된 토큰이 일치하지 않는 경우",
-            },
             "user not found": {
               value: {
                 message: "user not found",
@@ -152,7 +143,6 @@ export function ApiGoogleUnlink() {
         },
       },
     }),
-
     ApiResponse({
       status: 500,
       description: "Internal server error",


### PR DESCRIPTION
## 관련 이슈

#69 

## 개요

> 구글 로그아웃, 회원탈퇴 구현입니다. 로그아웃은 네이버와 같이 토큰들만 만료 시키고 회원탈퇴는 소셜 액세스를 이용합니다. 소셜 액세스 만료시 소셜 리프레시 만료여부 확인 후 소셜 리프레시가 만료되지 않았다면 소셜 리프레시를 통해 소셜 액세스를 자동으로 재발급해줍니다(카카오와 네이버랑 비슷합니다). 구글 리프레시 토큰이 안 오는줄 알았는데 인가코드 받을 때 옵션을 추가하면 받을 수 있다는 걸 알아서 로그인 로직 수정되었습니다 카톡으로 인가코드 받는 url 공유하겠습니다. 피드백 언제든지 환영입니다. 

## 작업 상세 내용

- [x] 구글 로그아웃
- [x] 구글 회원탈퇴
- [x] 구글 로그인 로직 수정

## 참고 자료(선택)
https://developers.google.com/identity/protocols/oauth2/web-server?hl=ko#httprest_8
https://m.blog.naver.com/nan17a/222182983858

