### PR TITLE
modify/#69

### DIFF
--- a/src/auth/services/auth.service.ts
+++ b/src/auth/services/auth.service.ts
@@ -95,6 +95,12 @@ export class AuthService {
           "naver",
         );
         await this.legendsRepository.createUserLegend(user.no);
+      } else {
+        await this.usersRepository.updateUser(
+          user.no,
+          userInfo.response.name,
+          userInfo.response.profile_image,
+        );
       }
 
       await this.usersRepository.updateDeleteAt(user.no, null);
@@ -185,12 +191,16 @@ export class AuthService {
 
       this.userInfoUrl = "https://kapi.kakao.com/v2/user/me";
       const userInfo = (
-        await axios.get(this.userInfoUrl, {
-          headers: {
-            "Content-Type": "application/x-www-form-urlencoded",
-            Authorization: `Bearer ${socialAccessToken}`,
+        await axios.post(
+          this.userInfoUrl,
+          { secure_resource: true },
+          {
+            headers: {
+              "Content-Type": "application/x-www-form-urlencoded",
+              Authorization: `Bearer ${socialAccessToken}`,
+            },
           },
-        })
+        )
       ).data;
 
       if (!userInfo) {
@@ -215,6 +225,12 @@ export class AuthService {
           "kakao",
         );
         await this.legendsRepository.createUserLegend(user.no);
+      } else {
+        await this.usersRepository.updateUser(
+          user.no,
+          userProperties.nickname,
+          userProperties.profile_image,
+        );
       }
 
       await this.usersRepository.updateDeleteAt(user.no, null);
@@ -327,6 +343,12 @@ export class AuthService {
           "google",
         );
         await this.legendsRepository.createUserLegend(user.no);
+      } else {
+        await this.usersRepository.updateUser(
+          user.no,
+          userInfo.name,
+          userInfo.picture,
+        );
       }
       await this.usersRepository.updateDeleteAt(user.no, null);
 

--- a/src/users/users.repository.ts
+++ b/src/users/users.repository.ts
@@ -22,6 +22,14 @@ export class UsersRepository {
     });
   }
 
+  updateUser(userNo: number, socialName: string, image: string) {
+    return this.prisma.user.update({
+      select: { no: true, image: true, socialName: true },
+      data: { image, socialName },
+      where: { no: userNo },
+    });
+  }
+
   createUser(
     uniqueIdentifier: string,
     socialName: string,


### PR DESCRIPTION
## 관련 이슈

#11 #69 

## 개요

> 카카오로 로그인 시 프로필 사진 url 이 http로 오는걸 https로 오게끔 수정, 그리고 기존 유저가 로그인할 때 닉네임과 프로필 이미지가 변경되었을 수도 있어서 닉네임, 프로필 이미지 업데이트 추가 

## 작업 상세 내용

- [ ] 카카오 프로필 사진 url https로 오게끔 수정
- [ ] 기존 유저 프로필 이미지, 닉네임 업데이트

## 참고 자료(선택)
https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api#req-user-info-request-query

